### PR TITLE
HeroImage being clipped on large screen.

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -59,6 +59,10 @@ svg {
 .bm-burger-bars {
   background: var(--color-tertiary);
 }
+
+#outer-container {
+  overflow: visible !important;
+}
 `
 
 const Layout = ({ children, location }) => {


### PR DESCRIPTION
There was an issue if your screen was too large (mine was 27" 5K) and if you opened the menu, the hero image was getting clipped.

I'm not sure if it's a nice fix, but it does the job.

See demonstration:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/4112343/51434034-139efe80-1c27-11e9-8a52-a2908d4d8c9c.gif)


_Feel free to refuse if this ain't a great quality fix :)_ 

